### PR TITLE
Colors for subjects

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
 		"vite": "^4.4.2",
-		"vite-plugin-pwa": "^0.16.5"
+		"vite-plugin-pwa": "^0.16.5",
+		"zod": "^3.22.4"
 	},
 	"type": "module",
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ devDependencies:
   vite-plugin-pwa:
     specifier: ^0.16.5
     version: 0.16.5(vite@4.5.0)(workbox-build@7.0.0)(workbox-window@7.0.0)
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 packages:
 
@@ -4710,4 +4713,8 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: true

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -123,6 +123,7 @@ const de = {
 	'settings.save': 'Speichern',
 	'settings.account': 'Account',
 	'settings.preferences': 'Einstellungen',
+	'settings.colors': 'Farben',
 	'settings.selectSpecificSection':
 		'Wähle links eine spezifische Sektion aus, um die Einstellungen zu ändern.',
 	'settings.apperance': 'Aussehen',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -133,6 +133,21 @@ const de = {
 	'settings.apperance.theme.dark': 'Dunkel',
 	'settings.apperance.nav.text': 'Titel in der Navigationsleiste anzeigen',
 
+	'settings.subjectColors': 'Farben für Fächer',
+	'settings.subjectColors.import': 'Importiere die Farben von einer JSON-Datei',
+	'settings.subjectColors.import.confirm':
+		'Bist du sicher, dass du die Farben importieren möchtest? Die aktuellen Farben werden überschrieben.',
+	'settings.subjectColors.export': 'Exportiere die Farben als JSON-Datei',
+	'settings.subjectColors.subject': 'Fach',
+	'settings.subjectColors.subject.remove': 'Fach entfernen',
+	'settings.subjectColors.subject.add': 'Neues Fach hinzufügen',
+
+	'colors.red': 'Rot',
+	'colors.green': 'Grün',
+	'colors.blue': 'Blau',
+
+	'colors.select': 'Farbe auswählen',
+
 	'printing.footer': 'Dein kollaboratives Hausaufgabenheft',
 	tricks: 'Tricks',
 	'tricks.export': 'Export',
@@ -233,6 +248,10 @@ const de = {
 
 	'toast.download.homework.success': 'Hausaufgaben erfolgreich heruntergeladen.',
 	'toast.download.homework.error': 'Hausaufgaben konnten nicht heruntergeladen werden.',
+
+	'toast.colors.import.success': 'Farben erfolgreich importiert.',
+	'toast.colors.import.invalidFile': 'Die Datei ist ungültig :(',
+	'toast.colors.import.error': 'Farben konnten nicht importiert werden.',
 
 	contributors: 'Mitwirkende',
 	'contributors.error': 'Mitwikende konnten nicht geladen werden.',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -141,6 +141,8 @@ const de = {
 	'settings.subjectColors.subject': 'Fach',
 	'settings.subjectColors.subject.remove': 'Fach entfernen',
 	'settings.subjectColors.subject.add': 'Neues Fach hinzufügen',
+	'settings.subjectColors.explaination':
+		'Diese Farben werden bei den Hausaufgaben und dem Kalendar verwendet, sie ermöglichen es dir die Hausaufgaben noch schneller einem Fach zuzuordnen. Du kannst soviele Fächer hinzufügen wie du möchtest.',
 
 	'colors.red': 'Rot',
 	'colors.green': 'Grün',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -122,6 +122,7 @@ const en = {
 	'settings.save': 'Save',
 	'settings.account': 'Account',
 	'settings.preferences': 'Preferences',
+	'settings.colors': 'Colors',
 	'settings.selectSpecificSection': 'Select a specific section on the left to change its settings',
 	'settings.apperance': 'Apperance',
 	'settings.apperance.theme': 'Theme',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -139,6 +139,8 @@ const en = {
 	'settings.subjectColors.subject': 'Subject',
 	'settings.subjectColors.subject.remove': 'Remove subject',
 	'settings.subjectColors.subject.add': 'Add subject',
+	'settings.subjectColors.explaination':
+		'These colors are used in the homework and calendar view. You can add as many subjects as you want.',
 
 	'colors.red': 'Red',
 	'colors.green': 'Green',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -131,6 +131,21 @@ const en = {
 	'settings.apperance.theme.dark': 'Dark',
 	'settings.apperance.nav.text': 'Show title in the navigation bar',
 
+	'settings.subjectColors': 'Colors for subjects',
+	'settings.subjectColors.import': 'Import colors from a JSON file',
+	'settings.subjectColors.import.confirm':
+		'Are you sure you want to import these colors? This will overwrite your current colors!',
+	'settings.subjectColors.export': 'Export colors to a JSON file',
+	'settings.subjectColors.subject': 'Subject',
+	'settings.subjectColors.subject.remove': 'Remove subject',
+	'settings.subjectColors.subject.add': 'Add subject',
+
+	'colors.red': 'Red',
+	'colors.green': 'Green',
+	'colors.blue': 'Blue',
+
+	'colors.select': 'Select color',
+
 	'printing.footer': 'Your collaborative homework book',
 	tricks: 'Tricks',
 	'tricks.export': 'export',
@@ -228,6 +243,10 @@ const en = {
 
 	'toast.download.homework.success': 'Successfully downloaded homework',
 	'toast.download.homework.error': 'Failed to download homework',
+
+	'toast.colors.import.success': 'Farben erfolgreich importiert.',
+	'toast.colors.import.invalidFile': 'Die Datei ist ungültig :(',
+	'toast.colors.import.error': 'Farben konnten nicht importiert werden.',
 
 	contributors: 'Contributors',
 	'contributors.error': "Could'nt fetch contributors",

--- a/src/lib/colors/ColorPicker.svelte
+++ b/src/lib/colors/ColorPicker.svelte
@@ -63,7 +63,6 @@
 
 		<SubmitButton
 			onClick={() => {
-				console.log(`rgb(${r},${g},${b})`);
 				open = false;
 			}}
 		>

--- a/src/lib/colors/ColorPicker.svelte
+++ b/src/lib/colors/ColorPicker.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import Modal from '$lib/Modal.svelte';
+	import SubmitButton from '$lib/SubmitButton.svelte';
+	import type { IntRange } from '../../types/utils';
+
+	export let r: IntRange<0, 256> = 0;
+	export let g: IntRange<0, 256> = 0;
+	export let b: IntRange<0, 256> = 0;
+
+	export let open = false;
+
+	const blackOrWhiteText = (r: number, g: number, b: number) => {
+		const brightness = Math.round((r * 299 + g * 587 + b * 114) / 1000);
+		return brightness > 125 ? 'black' : 'white';
+	};
+
+	let buttonTextColour = blackOrWhiteText(r, g, b);
+
+	$: buttonTextColour = blackOrWhiteText(r, g, b);
+</script>
+
+<div style="--red: {r}; --green: {g}; --blue: {b};">
+	<button
+		class="bg-[rgb(var(--red),var(--green),var(--blue))] w-full h-full rounded-sm px-2 py-1"
+		class:text-white={buttonTextColour === 'white'}
+		class:text-black={buttonTextColour === 'black'}
+		on:click={() => {
+			open = !open;
+		}}
+	>
+		Select
+	</button>
+
+	<Modal bind:open>
+		<div class="grid grid-cols-[1fr,3fr]">
+			Rot
+			<input
+				type="range"
+				bind:value={r}
+				min="0"
+				max="255"
+				class="w-full h-2 bg-[rgb(var(--red),0,0)] rounded-lg appearance-none cursor-pointer"
+			/>
+			Grün
+			<input
+				type="range"
+				bind:value={g}
+				min="0"
+				max="255"
+				class="w-full h-2 bg-[rgb(0,var(--green),0)] rounded-lg appearance-none cursor-pointer"
+			/>
+			Blau
+			<input
+				type="range"
+				bind:value={b}
+				min="0"
+				max="255"
+				class="w-full h-2 bg-[rgb(0,0,var(--blue))] rounded-lg appearance-none cursor-pointer"
+			/>
+		</div>
+
+		<div class="bg-[rgb(var(--red),var(--green),var(--blue))] w-full h-32 rounded-lg" />
+
+		<SubmitButton
+			onClick={() => {
+				console.log(`rgb(${r},${g},${b})`);
+				open = false;
+			}}
+		>
+			Select
+		</SubmitButton>
+	</Modal>
+</div>

--- a/src/lib/colors/ColorPicker.svelte
+++ b/src/lib/colors/ColorPicker.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+	import I18n from '$lib/I18n.svelte';
 	import Modal from '$lib/Modal.svelte';
 	import SubmitButton from '$lib/SubmitButton.svelte';
 	import type { IntRange } from '../../types/utils';
+	import { rgbToHex } from './hexToRgb';
 
-	export let r: IntRange<0, 256> = 0;
-	export let g: IntRange<0, 256> = 0;
-	export let b: IntRange<0, 256> = 0;
+	export let r: IntRange<0, 255> = 0;
+	export let g: IntRange<0, 255> = 0;
+	export let b: IntRange<0, 255> = 0;
 
 	export let open = false;
 
@@ -28,35 +30,43 @@
 			open = !open;
 		}}
 	>
-		Select
+		<slot>
+			{rgbToHex(r, g, b)}
+		</slot>
 	</button>
 
 	<Modal bind:open>
-		<div class="grid grid-cols-[1fr,3fr]">
-			Rot
-			<input
-				type="range"
-				bind:value={r}
-				min="0"
-				max="255"
-				class="w-full h-2 bg-[rgb(var(--red),0,0)] rounded-lg appearance-none cursor-pointer"
-			/>
-			Grün
-			<input
-				type="range"
-				bind:value={g}
-				min="0"
-				max="255"
-				class="w-full h-2 bg-[rgb(0,var(--green),0)] rounded-lg appearance-none cursor-pointer"
-			/>
-			Blau
-			<input
-				type="range"
-				bind:value={b}
-				min="0"
-				max="255"
-				class="w-full h-2 bg-[rgb(0,0,var(--blue))] rounded-lg appearance-none cursor-pointer"
-			/>
+		<div class="flex flex-col gap-2 py-2">
+			<div class="flex items-center gap-1">
+				<I18n key="colors.red" />
+				<input
+					type="range"
+					bind:value={r}
+					min="0"
+					max="255"
+					class="w-full h-2 bg-[rgb(var(--red),0,0)] rounded-lg appearance-none cursor-pointer"
+				/>
+			</div>
+			<div class="flex items-center gap-1">
+				<I18n key="colors.green" />
+				<input
+					type="range"
+					bind:value={g}
+					min="0"
+					max="255"
+					class="w-full h-2 bg-[rgb(0,var(--green),0)] rounded-lg appearance-none cursor-pointer"
+				/>
+			</div>
+			<div class="flex items-center gap-1">
+				<I18n key="colors.blue" />
+				<input
+					type="range"
+					bind:value={b}
+					min="0"
+					max="255"
+					class="w-full h-2 bg-[rgb(0,0,var(--blue))] rounded-lg appearance-none cursor-pointer"
+				/>
+			</div>
 		</div>
 
 		<div class="bg-[rgb(var(--red),var(--green),var(--blue))] w-full h-32 rounded-lg" />
@@ -66,7 +76,7 @@
 				open = false;
 			}}
 		>
-			Select
+			<I18n key="colors.select" />
 		</SubmitButton>
 	</Modal>
 </div>

--- a/src/lib/colors/downloadSubjectColors.ts
+++ b/src/lib/colors/downloadSubjectColors.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { subjectColorSchema } from '../../zod/subjectColor';
+import type { SubjectColor } from '../../types/subjectColors';
+
+export const readFileContent = (file: File): Promise<string> => {
+	const reader = new FileReader();
+	return new Promise((resolve, reject) => {
+		reader.onload = (event) => {
+			const result = event.target?.result;
+			if (typeof result !== 'string') {
+				reject('Could not read file');
+				return;
+			}
+			resolve(result);
+		};
+		reader.onerror = (error) => reject(error);
+		reader.readAsText(file);
+	});
+};
+
+export const checkIfValid = (content: string): boolean => {
+	try {
+		const parsed = JSON.parse(content);
+		if (!Array.isArray(parsed)) {
+			return false;
+		}
+	} catch {
+		return false;
+	}
+
+	const schema = z.array(subjectColorSchema);
+
+	const zodResult = schema.safeParse(JSON.parse(content));
+	if (!zodResult.success) {
+		return false;
+	}
+
+	return true;
+};
+
+export const parseContent = (correctContent: string): SubjectColor[] => {
+	const schema = z.array(subjectColorSchema);
+
+	const zodResult = schema.safeParse(JSON.parse(correctContent));
+	if (!zodResult.success) {
+		throw new Error('Could not parse content');
+	}
+
+	return zodResult.data as SubjectColor[];
+};

--- a/src/lib/colors/hexToRgb.ts
+++ b/src/lib/colors/hexToRgb.ts
@@ -1,0 +1,13 @@
+import type { IntRange } from '../../types/utils';
+
+export const hexToRgb = (
+	hex: string
+): {
+	r: IntRange<0, 255>;
+	g: IntRange<0, 255>;
+	b: IntRange<0, 255>;
+} => ({
+	r: parseInt(hex.slice(1, 3), 16) as IntRange<0, 255>,
+	g: parseInt(hex.slice(3, 5), 16) as IntRange<0, 255>,
+	b: parseInt(hex.slice(5, 7), 16) as IntRange<0, 255>
+});

--- a/src/lib/colors/hexToRgb.ts
+++ b/src/lib/colors/hexToRgb.ts
@@ -1,13 +1,21 @@
 import type { IntRange } from '../../types/utils';
 
+type Range = IntRange<0, 255>;
+
 export const hexToRgb = (
 	hex: string
 ): {
-	r: IntRange<0, 255>;
-	g: IntRange<0, 255>;
-	b: IntRange<0, 255>;
+	r: Range;
+	g: Range;
+	b: Range;
 } => ({
-	r: parseInt(hex.slice(1, 3), 16) as IntRange<0, 255>,
-	g: parseInt(hex.slice(3, 5), 16) as IntRange<0, 255>,
-	b: parseInt(hex.slice(5, 7), 16) as IntRange<0, 255>
+	r: parseInt(hex.slice(1, 3), 16) as Range,
+	g: parseInt(hex.slice(3, 5), 16) as Range,
+	b: parseInt(hex.slice(5, 7), 16) as Range
 });
+
+// create a function to make any decimal number a hex number with 2 digits
+const makeHex = (n: number): string => n.toString(16).padStart(2, '0');
+
+export const rgbToHex = (r: Range, g: Range, b: Range): string =>
+	`#${makeHex(r)}${makeHex(g)}${makeHex(b)}`;

--- a/src/lib/dates/dateIsInPast.ts
+++ b/src/lib/dates/dateIsInPast.ts
@@ -1,0 +1,8 @@
+import type { CustomDate } from '../../types/customDate';
+
+export const dateIsInPast = (date: CustomDate) => {
+	const now = new Date();
+	const customDate = new Date(date.year, date.month - 1, date.day); // month should be 0-based in JavaScript
+
+	return customDate < now;
+};

--- a/src/lib/events/EventBox.svelte
+++ b/src/lib/events/EventBox.svelte
@@ -7,6 +7,8 @@
 	import EventBoxInner from './EventBoxInner.svelte';
 	import Modal from '$lib/Modal.svelte';
 	import { isEventOver } from './isEventOver';
+	import { subjectColors } from '../../routes/stores';
+	import { rgbToHex } from '$lib/colors/hexToRgb';
 
 	export let event: Event;
 
@@ -14,13 +16,29 @@
 
 	let shareEnabled = false;
 
+	let color = $subjectColors.find(
+		(color) => color.subject.toLowerCase() === event.subject.toLowerCase()
+	)?.color;
+
 	onMount(() => {
 		shareEnabled = !!navigator.share;
 	});
 </script>
 
 <Box id={event._id} secondary={isEventOver(event)}>
-	<EventBoxInner {event} />
+	<div class="flex gap-1">
+		{#if color}
+			<div class="py-1 w-1">
+				<div
+					style="--color: {rgbToHex(color.r, color.g, color.b)}"
+					class="bg-[var(--color)] h-full w-full rounded-full"
+				/>
+			</div>
+		{/if}
+		<div class="w-full">
+			<EventBoxInner {event} />
+		</div>
+	</div>
 
 	<div class="w-full flex flex-row items-center justify-evenly">
 		{#if shareEnabled}

--- a/src/lib/homework/DataBoxAssignment.svelte
+++ b/src/lib/homework/DataBoxAssignment.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { dateIsInPast } from '$lib/dates/dateIsInPast';
+	import DateLabel from '$lib/dates/dateLabel.svelte';
+	import { getIconForSubject, iconExistsForSubject } from '../../constants/subjecticons';
+	import { subjectColors } from '../../routes/stores';
+	import type { Assignment } from '../../types/homework';
+
+	export let assignment: Assignment;
+
+	let isOverdue = dateIsInPast(assignment.due);
+	let color = $subjectColors[assignment.subject.toLowerCase()] || '';
+
+	subjectColors.subscribe((colors) => {
+		color = colors[assignment.subject.toLowerCase()] || '';
+	});
+
+	$: isOverdue = dateIsInPast(assignment.due);
+	$: color = $subjectColors[assignment.subject.toLowerCase()] || '';
+</script>
+
+<div class="w-full flex flex-row gap-2" class:opacity-50={isOverdue}>
+	{#if color}
+		<div style="--c: {color}" class="inline-block bg-[var(--c)] w-1 rounded-full" />
+	{/if}
+	<div>
+		<span class="flex flex-row items-baseline justify-start gap-2 my-2">
+			{#if iconExistsForSubject(assignment.subject.toLowerCase())}
+				<i class="bx {getIconForSubject(assignment.subject.toLowerCase())}" />
+			{/if}
+			<h4>{assignment.subject}</h4>
+			<DateLabel date={assignment.due} />
+		</span>
+		<p class="my-2 whitespace-pre-line">{assignment.description}</p>
+	</div>
+</div>
+<div class="hidden print:flex items-start">
+	<div class="w-4 h-4 rounded-md border border-solid border-gray-400" />
+</div>

--- a/src/lib/homework/DataBoxAssignment.svelte
+++ b/src/lib/homework/DataBoxAssignment.svelte
@@ -39,7 +39,12 @@
 
 <div class="w-full flex flex-row gap-2" class:opacity-50={isOverdue}>
 	{#if colorHex}
-		<div style="--c: {colorHex}" class="inline-block bg-[var(--c)] w-1 rounded-full" />
+	<div class="py-2 w-1">
+		<div
+			style="--color: {colorHex}"
+			class="bg-[var(--color)] h-full w-full rounded-full"
+		/>
+	</div>
 	{/if}
 	<div>
 		<span class="flex flex-row items-baseline justify-start gap-2 my-2">

--- a/src/lib/homework/DataBoxAssignment.svelte
+++ b/src/lib/homework/DataBoxAssignment.svelte
@@ -39,12 +39,9 @@
 
 <div class="w-full flex flex-row gap-2" class:opacity-50={isOverdue}>
 	{#if colorHex}
-	<div class="py-2 w-1">
-		<div
-			style="--color: {colorHex}"
-			class="bg-[var(--color)] h-full w-full rounded-full"
-		/>
-	</div>
+		<div class="py-2 w-1">
+			<div style="--color: {colorHex}" class="bg-[var(--color)] h-full w-full rounded-full" />
+		</div>
 	{/if}
 	<div>
 		<span class="flex flex-row items-baseline justify-start gap-2 my-2">

--- a/src/lib/homework/DataBoxAssignment.svelte
+++ b/src/lib/homework/DataBoxAssignment.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { rgbToHex } from '$lib/colors/hexToRgb';
 	import { dateIsInPast } from '$lib/dates/dateIsInPast';
 	import DateLabel from '$lib/dates/dateLabel.svelte';
 	import { getIconForSubject, iconExistsForSubject } from '../../constants/subjecticons';
@@ -8,19 +9,37 @@
 	export let assignment: Assignment;
 
 	let isOverdue = dateIsInPast(assignment.due);
-	let color = $subjectColors[assignment.subject.toLowerCase()] || '';
+	let subjColor = $subjectColors.filter(
+		(v) => v.subject.toLowerCase() === assignment.subject.toLowerCase()
+	);
+	let colorHex =
+		subjColor.length > 0
+			? rgbToHex(subjColor[0].color.r, subjColor[0].color.g, subjColor[0].color.b)
+			: '';
 
 	subjectColors.subscribe((colors) => {
-		color = colors[assignment.subject.toLowerCase()] || '';
+		subjColor = colors.filter((v) => v.subject.toLowerCase() === assignment.subject.toLowerCase());
+		colorHex =
+			subjColor.length > 0
+				? rgbToHex(subjColor[0].color.r, subjColor[0].color.g, subjColor[0].color.b)
+				: '';
 	});
 
 	$: isOverdue = dateIsInPast(assignment.due);
-	$: color = $subjectColors[assignment.subject.toLowerCase()] || '';
+	$: {
+		subjColor = $subjectColors.filter(
+			(v) => v.subject.toLowerCase() === assignment.subject.toLowerCase()
+		);
+		colorHex =
+			subjColor.length > 0
+				? rgbToHex(subjColor[0].color.r, subjColor[0].color.g, subjColor[0].color.b)
+				: '';
+	}
 </script>
 
 <div class="w-full flex flex-row gap-2" class:opacity-50={isOverdue}>
-	{#if color}
-		<div style="--c: {color}" class="inline-block bg-[var(--c)] w-1 rounded-full" />
+	{#if colorHex}
+		<div style="--c: {colorHex}" class="inline-block bg-[var(--c)] w-1 rounded-full" />
 	{/if}
 	<div>
 		<span class="flex flex-row items-baseline justify-start gap-2 my-2">

--- a/src/lib/homework/DataBoxInner.svelte
+++ b/src/lib/homework/DataBoxInner.svelte
@@ -4,7 +4,6 @@
 	import SubmitButton from '$lib/SubmitButton.svelte';
 	import TimeAgo from '$lib/dates/TimeAgo.svelte';
 	import html2canvas from 'html2canvas';
-	import { getIconForSubject, iconExistsForSubject } from '../../constants/subjecticons';
 	import { i } from '../../languages/i18n';
 	import type { CustomDate } from '../../types/customDate';
 	import type { Assignment } from '../../types/homework';

--- a/src/lib/homework/DataBoxInner.svelte
+++ b/src/lib/homework/DataBoxInner.svelte
@@ -13,6 +13,7 @@
 	import CreateHomeworkInner from './CreateHomeworkInner.svelte';
 	import { addToast } from '$lib/toast/addToast';
 	import { network } from '../../routes/stores';
+	import DataBoxAssignment from './DataBoxAssignment.svelte';
 
 	export let date: CustomDate;
 	export let assignments: Assignment[];
@@ -75,29 +76,17 @@
 		</h3>
 		<TimeAgo classes="text-xs" timestamp={createdAt} type="edited" />
 	</div>
-	<ul class="list-none p-0">
-		{#if editMode}
-			<CreateHomeworkInner bind:assignments={newAssignments} />
-		{:else}
+	{#if editMode}
+		<CreateHomeworkInner bind:assignments={newAssignments} />
+	{:else}
+		<ul class="list-none p-0 flex flex-col gap-3">
 			{#each assignments as assignment}
-				<li class="flex flex-row">
-					<div class="w-full">
-						<span class="flex flex-row items-baseline justify-start gap-2 my-2">
-							{#if iconExistsForSubject(assignment.subject.toLowerCase())}
-								<i class="bx {getIconForSubject(assignment.subject.toLowerCase())}" />
-							{/if}
-							<h4>{assignment.subject}</h4>
-							<DateLabel date={assignment.due} />
-						</span>
-						<p class="my-2 whitespace-pre-line">{assignment.description}</p>
-					</div>
-					<div class="hidden print:flex items-start">
-						<div class="w-4 h-4 rounded-md border border-solid border-gray-400" />
-					</div>
+				<li>
+					<DataBoxAssignment {assignment} />
 				</li>
 			{/each}
-		{/if}
-	</ul>
+		</ul>
+	{/if}
 	{#if editMode}
 		<SubmitButton
 			value="Update"

--- a/src/lib/layout/SubjectColors.svelte
+++ b/src/lib/layout/SubjectColors.svelte
@@ -2,20 +2,19 @@
 	import { getLocalstorage, setLocalstorage } from '$lib/localstorage';
 	import { onMount } from 'svelte';
 	import { subjectColors } from '../../routes/stores';
+	import type { SubjectColor } from '../../types/subjectColors';
 
-    let readFromLocalstorage = false;
+	let readFromLocalstorage = false;
 
 	subjectColors.subscribe((v) => {
 		if (readFromLocalstorage) setLocalstorage('subjectColors', v);
 	});
 
 	onMount(() => {
-        const locRes = getLocalstorage<Record<string, string>>('subjectColors', {})
-        console.log(locRes)
-        console.log(
-            localStorage.getItem('subjectColors')
-        )
+		const locRes = getLocalstorage<SubjectColor[]>('subjectColors', []);
+		console.log(locRes);
+		console.log(localStorage.getItem('subjectColors'));
 		subjectColors.set(locRes);
-        readFromLocalstorage = true;
+		readFromLocalstorage = true;
 	});
 </script>

--- a/src/lib/layout/SubjectColors.svelte
+++ b/src/lib/layout/SubjectColors.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { getLocalstorage, setLocalstorage } from '$lib/localstorage';
+	import { onMount } from 'svelte';
+	import { subjectColors } from '../../routes/stores';
+
+    let readFromLocalstorage = false;
+
+	subjectColors.subscribe((v) => {
+		if (readFromLocalstorage) setLocalstorage('subjectColors', v);
+	});
+
+	onMount(() => {
+        const locRes = getLocalstorage<Record<string, string>>('subjectColors', {})
+        console.log(locRes)
+        console.log(
+            localStorage.getItem('subjectColors')
+        )
+		subjectColors.set(locRes);
+        readFromLocalstorage = true;
+	});
+</script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
 	import Language from '$lib/layout/Language.svelte';
 	import Logout from '$lib/layout/Logout.svelte';
 	import Theme from '$lib/layout/Theme.svelte';
+	import SubjectColors from '$lib/layout/SubjectColors.svelte';
 
 	let footerHeight = 0;
 	let navbarHeight = 0;
@@ -52,6 +53,8 @@
 <Language />
 <Theme />
 <Logout />
+<SubjectColors />
+<!--Those apply settings, update stores...-->
 
 <style>
 	main {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -54,6 +54,7 @@
 <Theme />
 <Logout />
 <SubjectColors />
+
 <!--Those apply settings, update stores...-->
 
 <style>

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -15,6 +15,11 @@
 			name: 'settings.preferences',
 			uri: '/preferences',
 			'box-icon': 'bx-cog'
+		},
+		{
+			name: 'settings.colors',
+			uri: '/colors',
+			'box-icon': 'bx-palette'
 		}
 	] as const;
 

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -107,6 +107,8 @@
 			</div>
 		</div>
 
+		<p><I18n key="settings.subjectColors.explaination" /></p>
+
 		<div class="flex flex-col gap-4">
 			{#each data as entry}
 				<div class="flex flex-row gap-2 items-center justify-between">

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -6,6 +6,7 @@
 	import { addToast } from '$lib/toast/addToast';
 	import I18n from '$lib/I18n.svelte';
 	import { i } from '../../../languages/i18n';
+	import { subjectsSortetCapitalized } from '../../../constants/subjecticons';
 
 	let data = $subjectColors;
 
@@ -117,6 +118,7 @@
 								bind:value={entry.subject}
 								class="rounded-sm text-light-text dark:text-light-text px-2 py-0.5"
 								placeholder={i('settings.subjectColors.subject')}
+								list="subjects"
 							/>
 							<QuickActionButton
 								iconName="bx-trash"
@@ -133,7 +135,11 @@
 					</div>
 				</div>
 			{/each}
-
+			<datalist id="subjects">
+				{#each subjectsSortetCapitalized as subj}
+					<option value={subj} />
+				{/each}
+			</datalist>
 			<button
 				on:click={() => {
 					data = [

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import QuickActionButton from '$lib/QuickActionButton.svelte';
 	import ColorPicker from '$lib/colors/ColorPicker.svelte';
-	import { hexToRgb } from '$lib/colors/hexToRgb';
+	import { hexToRgb, rgbToHex } from '$lib/colors/hexToRgb';
 	import type { IntRange } from '../../../types/utils';
 	import { subjectColors } from '../../stores';
 
@@ -16,6 +16,29 @@
 		subject,
 		color: hexToRgb($subjectColors[subject])
 	}));
+
+    subjectColors.subscribe((colors) => {
+        data = Object.keys(colors).map((subject) => ({
+            subject,
+            color: hexToRgb(colors[subject])
+        }));
+    })
+
+	const save = () => {
+		const colors: Record<string, string> = {};
+
+		data.forEach((entry) => {
+			colors[entry.subject.toLowerCase()] = rgbToHex(entry.color.r, entry.color.g, entry.color.b);
+		});
+
+		subjectColors.set(colors);
+	};
+
+	$: {
+		save();
+
+		data;
+	}
 </script>
 
 <div>
@@ -27,7 +50,11 @@
 					<ColorPicker bind:r={entry.color.r} bind:g={entry.color.g} bind:b={entry.color.b} />
 
 					<div class="flex flex-row items-center">
-						<input bind:value={entry.subject} class="rounded-sm text-light-text dark:text-light-text px-2 py-0.5" placeholder="Fach" />
+						<input
+							bind:value={entry.subject}
+							class="rounded-sm text-light-text dark:text-light-text px-2 py-0.5"
+							placeholder="Fach"
+						/>
 						<QuickActionButton
 							iconName="bx-trash"
 							focusedIconName="bx-trash"
@@ -42,6 +69,7 @@
 					</div>
 				</div>
 			{/each}
+
 			<button
 				on:click={() => {
 					data = [

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -1,38 +1,15 @@
 <script lang="ts">
 	import QuickActionButton from '$lib/QuickActionButton.svelte';
 	import ColorPicker from '$lib/colors/ColorPicker.svelte';
-	import { hexToRgb, rgbToHex } from '$lib/colors/hexToRgb';
-	import type { IntRange } from '../../../types/utils';
 	import { subjectColors } from '../../stores';
 
-	let data: {
-		subject: string;
-		color: {
-			r: IntRange<0, 255>;
-			g: IntRange<0, 255>;
-			b: IntRange<0, 255>;
-		};
-	}[] = Object.keys($subjectColors).map((subject) => ({
-		subject,
-		color: hexToRgb($subjectColors[subject])
-	}));
+	let data = $subjectColors;
 
-    subjectColors.subscribe((colors) => {
-        data = Object.keys(colors).map((subject) => ({
-            subject,
-            color: hexToRgb(colors[subject])
-        }));
-    })
+	subjectColors.subscribe((colors) => {
+		data = colors;
+	});
 
-	const save = () => {
-		const colors: Record<string, string> = {};
-
-		data.forEach((entry) => {
-			colors[entry.subject.toLowerCase()] = rgbToHex(entry.color.r, entry.color.g, entry.color.b);
-		});
-
-		subjectColors.set(colors);
-	};
+	const save = () => subjectColors.set(data);
 
 	$: {
 		save();

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import QuickActionButton from '$lib/QuickActionButton.svelte';
+	import ColorPicker from '$lib/colors/ColorPicker.svelte';
+	import { hexToRgb } from '$lib/colors/hexToRgb';
+	import type { IntRange } from '../../../types/utils';
+	import { subjectColors } from '../../stores';
+
+	let data: {
+		subject: string;
+		color: {
+			r: IntRange<0, 255>;
+			g: IntRange<0, 255>;
+			b: IntRange<0, 255>;
+		};
+	}[] = Object.keys($subjectColors).map((subject) => ({
+		subject,
+		color: hexToRgb($subjectColors[subject])
+	}));
+</script>
+
+<div>
+	<section>
+		<h3>Farben für Fächer</h3>
+		<div class="flex flex-col gap-4">
+			{#each data as entry}
+				<div class="flex flex-row gap-2 items-center justify-between">
+					<ColorPicker bind:r={entry.color.r} bind:g={entry.color.g} bind:b={entry.color.b} />
+
+					<div class="flex flex-row items-center">
+						<input bind:value={entry.subject} class="rounded-sm text-light-text dark:text-light-text px-2 py-0.5" placeholder="Fach" />
+						<QuickActionButton
+							iconName="bx-trash"
+							focusedIconName="bx-trash"
+							color="text-red-500 dark:text-red-400"
+							title="Farbe entfernen"
+							on:click={() => {
+								const index = data.indexOf(entry);
+								data.splice(index, 1);
+								data = [...data];
+							}}
+						/>
+					</div>
+				</div>
+			{/each}
+			<button
+				on:click={() => {
+					data = [
+						...data,
+						{
+							subject: '',
+							color: {
+								r: 63,
+								g: 81,
+								b: 181
+							}
+						}
+					];
+				}}
+			>
+				Neues Fach hinzufügen
+			</button>
+		</div>
+	</section>
+</div>

--- a/src/routes/settings/colors/+page.svelte
+++ b/src/routes/settings/colors/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import QuickActionButton from '$lib/QuickActionButton.svelte';
 	import ColorPicker from '$lib/colors/ColorPicker.svelte';
+	import { checkIfValid, parseContent, readFileContent } from '$lib/colors/downloadSubjectColors';
 	import { subjectColors } from '../../stores';
+	import { addToast } from '$lib/toast/addToast';
 
 	let data = $subjectColors;
 
@@ -20,7 +22,76 @@
 
 <div>
 	<section>
-		<h3>Farben für Fächer</h3>
+		<div class="flex justify-between">
+			<h3>Farben für Fächer</h3>
+
+			<div class="flex items-center gap-1">
+				<QuickActionButton
+					iconName="bxs-file-import"
+					color="text-green-500 dark:text-green-400"
+					title="Importiere die Farben von einer JSON-Datei"
+					on:click={() => {
+						if (
+							!confirm(
+								'Bist du sicher, dass du die Farben importieren möchtest? Die aktuellen Farben werden überschrieben.'
+							)
+						)
+							return;
+
+						const input = document.createElement('input');
+						input.type = 'file';
+						input.accept = '.json';
+
+						input.onchange = async () => {
+							const files = input.files;
+							if (!files) return;
+							const file = files[0];
+							if (!file) return;
+
+							const content = await readFileContent(file);
+							const isValid = checkIfValid(content);
+
+							if (!isValid) {
+								addToast({
+									type: 'error',
+									content: 'error',
+									// content: 'toast.colors.import.error',
+									duration: 5000
+								});
+								return;
+							}
+
+							const parsed = parseContent(content);
+							data = parsed;
+							addToast({
+								type: 'success',
+								// content: 'toast.colors.import.success',
+								content: 'class',
+								duration: 5000
+							});
+						};
+
+						input.click();
+					}}
+				/>
+
+				<QuickActionButton
+					iconName="bx-cloud-download"
+					focusedIconName="bxs-cloud-download"
+					color="text-blue-500 dark:text-blue-400"
+					title="Downloade die Farben als JSON"
+					on:click={() => {
+						const dataStr =
+							'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(data));
+						const downloadAnchorNode = document.createElement('a');
+						downloadAnchorNode.setAttribute('href', dataStr);
+						downloadAnchorNode.download = 'subjectColors.json';
+
+						downloadAnchorNode.click();
+					}}
+				/>
+			</div>
+		</div>
 		<div class="flex flex-col gap-4">
 			{#each data as entry}
 				<div class="flex flex-row gap-2 items-center justify-between">

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -24,3 +24,5 @@ export const settings = writable<{
 }>({
 	showTextInNavbar: true
 });
+
+export const subjectColors = writable<Record<string, string>>({});

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -3,6 +3,7 @@ import type { Note } from '../types/notes';
 import type { Event } from '../types/events';
 import type { Languages, Token } from '../languages/i18n';
 import type { Toast } from '../types/toast';
+import type { SubjectColor } from '../types/subjectColors';
 
 export const focusedNote = writable<Note | null>(null);
 export const showHomeworkFilter = writable<boolean>(false);
@@ -25,4 +26,4 @@ export const settings = writable<{
 	showTextInNavbar: true
 });
 
-export const subjectColors = writable<Record<string, string>>({});
+export const subjectColors = writable<SubjectColor[]>([]);

--- a/src/types/subjectColors.ts
+++ b/src/types/subjectColors.ts
@@ -1,0 +1,14 @@
+import type { IntRange } from './utils';
+
+type RangeRGB = IntRange<0, 255>;
+
+export type RGB = {
+	r: RangeRGB;
+	g: RangeRGB;
+	b: RangeRGB;
+};
+
+export type SubjectColor = {
+	subject: string;
+	color: RGB;
+};

--- a/src/zod/subjectColor.ts
+++ b/src/zod/subjectColor.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const subjectColorSchema = z.object({
+	subject: z.string(),
+	color: z.object({
+		r: z.number().max(255).min(0),
+		g: z.number().max(255).min(0),
+		b: z.number().max(255).min(0)
+	})
+});


### PR DESCRIPTION
This PR brings in the option to add colors to subjects. Users can now customize the colors for their subjects in the settings menu. These chosen colors will be displayed on the homework interface, as shown in the screenshots below.

The selected color data will be stored in local storage and won't be shared automatically. This means that users can still have their own unique color preferences for each subject. For example, one user can have *'Computer Science'* in yellow, while another can choose green.

Moreover, it's still possible to share this color configuration by exporting/importing a JSON file. This feature allows you to easily share your color preferences not only between your own devices but also with others.

![Dlool-homework(1)](https://github.com/Dlurak/dloolFrontend/assets/84224239/9b92d132-c9c4-4d12-b639-dfa12bccd4ec)
![Dlool-homework](https://github.com/Dlurak/dloolFrontend/assets/84224239/a820b904-9866-4c3c-a487-608519633582)
